### PR TITLE
Change 'written entries' log level from 'info' to 'debug'

### DIFF
--- a/lib/fluent/plugin/out_scribe.rb
+++ b/lib/fluent/plugin/out_scribe.rb
@@ -97,7 +97,7 @@ class ScribeOutput < BufferedOutput
         entries << entry
       end
 
-      $log.info "Writing #{entries.count} entries to scribe"
+      $log.debug "Writing #{entries.count} entries to scribe"
       client.Log(entries)
     ensure
       transport.close


### PR DESCRIPTION
"Writing ... entries to scribe' logs are too many lines to output with 'info' level.
