### PR TITLE
Improve invalid record handling

### DIFF
--- a/fluent-plugin-scribe.gemspec
+++ b/fluent-plugin-scribe.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "test-unit", '~> 3.0.2'
   gem.add_runtime_dependency "fluentd"
   gem.add_runtime_dependency "thrift", "~> 0.8.0"
 end


### PR DESCRIPTION
- Use Yajl for JSON parsing
- Add ignore_invalid_record option to ignore invalid record and return OK to scribed

From this PR, `in_scribe` has 3 behaviours for invalid record.
- Return TRY_LATER to scribed(default for keeping existence behaviour)

``` aconf
<source>
  type scribe
  # ...
</source>
```
- logging invalid record and return OK to scribed

``` aconf
<source>
  type scribe
  # ...
  ignore_invalid_record
</source>
```
- No logging and return OK to scribed

``` aconf
<source>
  type scribe
  # ...
  ignore_invalid_record
  log_level error
</source>
```
